### PR TITLE
Added category average data point

### DIFF
--- a/src/model/parameters.ts
+++ b/src/model/parameters.ts
@@ -796,4 +796,15 @@ export const modelParameters: ModelParameter[] = [
     connectedEntityIds: [`country/${countryDefault}`],
     version: ModelVersion.version_0_1_0,
   },
+  {
+    id: "fixedValue/categoryAverageEmissions/shoes/sneakers",
+    label: "Average CO2e emissions for the Shoes/Sneakers category",
+    source:
+      "Using carbon footprint of a typical pair of running shoes made of synthetic materials ([source MIT](https://dspace.mit.edu/bitstream/handle/1721.1/102070/Olivetti_Manufacturing-focused.pdf)). Using this value as a proxy for the sneakers category until we can find or create data on this specific category.",
+    value: 14,
+    variationCoefficient: 0.2,
+    unit: "kgCO2eq",
+    connectedEntityIds: [`country/${countryDefault}`],
+    version: ModelVersion.version_0_2_1,
+  },
 ];

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -5,6 +5,7 @@ export interface ModelParameter {
   label: string; // a human-readable string to display the model parameter in the UI
   source: string; // human-readable explanation and sources
   value: number;
+  variationCoefficient?: number;
   unit: "kgCO2eq" | "kgCO2eq/kg" | "kWh" | "kgCO2eq/kWh";
   connectedEntityIds: string[];
   comments?: string;


### PR DESCRIPTION
Fixes #2 

- For now, we use the running shoes average footprint documented in MIT's study as a proxy for the sneakers category. We will work soon on making the comparison reference more adequate based on the observed product.
- Added an optional `variationCoefficient` field to `ModelParameter` that will be useful to start estimating variation coefficients / error margins in the computations.